### PR TITLE
Add AGENTS.md for Cursor Cloud development environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **pure TypeScript library** (`@grom.js/tgx`) — a JSX runtime for composing Telegram Bot messages. There are no services, databases, or Docker containers.
+
+### Key commands
+
+All commands are in `package.json` scripts. Quick reference:
+
+| Task | Command |
+|---|---|
+| Install deps | `pnpm install --frozen-lockfile` |
+| Lint | `pnpm run lint` |
+| Typecheck | `pnpm run typecheck` |
+| Test | `pnpm run test` (watch mode) or `pnpm run test -- --run` (single run) |
+| Build | `pnpm run build` |
+
+### Gotchas
+
+- **TypeScript is not a direct devDependency** — it is resolved transitively via `@antfu/eslint-config`. The `tsc` binary is not accessible via `pnpm exec`. The update script installs `typescript` globally to make `tsc` available for `build` and `typecheck` scripts.
+- **esbuild postinstall**: pnpm may warn about ignored build scripts for `esbuild`. This does not affect vitest (which bundles its own esbuild wasm fallback) but may emit a warning during install.
+- **Vitest runs in watch mode by default** — use `pnpm run test -- --run` for a single pass.
+- **ESM only** — the package uses `"type": "module"`. All dist output is ESM.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for developing in this codebase.

### What's included

- Key commands reference (lint, typecheck, test, build)
- Non-obvious gotchas:
  - `typescript` is only a transitive dependency (not directly in devDependencies), so `tsc` needs global install
  - esbuild postinstall warning from pnpm is cosmetic
  - Vitest runs in watch mode by default
  - Package is ESM-only

### Environment verification

All checks pass:
- `pnpm run lint` — clean
- `pnpm run typecheck` — clean
- `pnpm run test -- --run` — 55/55 tests pass
- `pnpm run build` — produces `dist/` output
- Hello-world JSX-to-HTML rendering verified with built output
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eec05cde-740d-4082-99da-80c185c385a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eec05cde-740d-4082-99da-80c185c385a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

